### PR TITLE
Update url

### DIFF
--- a/packages/easycrypt/easycrypt.dev/url
+++ b/packages/easycrypt/easycrypt.dev/url
@@ -1,1 +1,1 @@
-git: "git://ci.easycrypt.info/easycrypt.git"
+git: "git://github.com/EasyCrypt/easycrypt.git"


### PR DESCRIPTION
I failed to install easyrypt using opam because git://ci.easycrypt.info/easycrypt.git is (temporalily?) down.
Using github repo fixes this.

Thanks

Update: I am behind a proxy server  and accessing ci.easycrypt.info using https. The problem may depend on my environment.